### PR TITLE
feat: add account-level KB sidebar visibility toggle

### DIFF
--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -33,6 +33,7 @@ class AccountDashboard < Administrate::BaseDashboard
     conversations: CountField,
     locale: Field::Select.with_options(collection: LANGUAGES_CONFIG.map { |_x, y| y[:iso_639_1_code] }),
     status: Field::Select.with_options(collection: [%w[Active active], %w[Suspended suspended]]),
+    knowledge_base_sidebar_enabled: Field::Boolean,
     account_users: Field::HasMany,
     custom_attributes: Field::String
   }.merge(enterprise_attribute_types).freeze
@@ -68,6 +69,7 @@ class AccountDashboard < Administrate::BaseDashboard
     updated_at
     locale
     status
+    knowledge_base_sidebar_enabled
     conversations
     account_users
   ] + enterprise_show_page_attributes).freeze
@@ -87,6 +89,7 @@ class AccountDashboard < Administrate::BaseDashboard
     name
     locale
     status
+    knowledge_base_sidebar_enabled
   ] + enterprise_form_attributes).freeze
 
   # COLLECTION_FILTERS

--- a/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
+++ b/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
@@ -23,7 +23,7 @@ const emit = defineEmits([
   'showCreateAccountModal',
 ]);
 
-const { accountScopedRoute } = useAccount();
+const { accountScopedRoute, currentAccount } = useAccount();
 const store = useStore();
 const searchShortcut = useKbd([`$mod`, 'k']);
 const { t } = useI18n();
@@ -104,6 +104,17 @@ const newReportRoutes = () => [
 ];
 
 const reportRoutes = computed(() => newReportRoutes());
+const isKnowledgeBaseSidebarEnabled = computed(() => {
+  const value = currentAccount.value?.settings?.knowledge_base_sidebar_enabled;
+
+  if (value === undefined || value === null || value === '') return true;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    return !['false', '0', 'off', 'no'].includes(value.toLowerCase());
+  }
+
+  return Boolean(value);
+});
 
 const menuItems = computed(() => {
   return [
@@ -220,13 +231,17 @@ const menuItems = computed(() => {
         },
       ],
     },
-    {
-      name: 'Knowledge Base',
-      icon: 'i-lucide-brain',
-      label: t('SIDEBAR.KNOWLEDGE_BASE'),
-      to: accountScopedRoute('knowledge_bases_index'),
-      activeOn: ['knowledge_bases_index', 'knowledge_base_show'],
-    },
+    ...(isKnowledgeBaseSidebarEnabled.value
+      ? [
+          {
+            name: 'Knowledge Base',
+            icon: 'i-lucide-brain',
+            label: t('SIDEBAR.KNOWLEDGE_BASE'),
+            to: accountScopedRoute('knowledge_bases_index'),
+            activeOn: ['knowledge_bases_index', 'knowledge_base_show'],
+          },
+        ]
+      : []),
     {
       name: 'Contacts',
       label: t('SIDEBAR.CONTACTS'),

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -37,7 +37,8 @@ class Account < ApplicationRecord
         'auto_resolve_message': { 'type': %w[string null] },
         'auto_resolve_ignore_waiting': { 'type': %w[boolean null] },
         'audio_transcriptions': { 'type': %w[boolean null] },
-        'auto_resolve_label': { 'type': %w[string null] }
+        'auto_resolve_label': { 'type': %w[string null] },
+        'knowledge_base_sidebar_enabled': { 'type': %w[boolean null] }
       },
     'required': [],
     'additionalProperties': true
@@ -55,6 +56,7 @@ class Account < ApplicationRecord
 
   store_accessor :settings, :auto_resolve_after, :auto_resolve_message, :auto_resolve_ignore_waiting
   store_accessor :settings, :audio_transcriptions, :auto_resolve_label
+  store_accessor :settings, :knowledge_base_sidebar_enabled
 
   has_many :account_users, dependent: :destroy_async
   has_many :agent_bot_inboxes, dependent: :destroy_async
@@ -158,6 +160,18 @@ class Account < ApplicationRecord
     # we need to extract the language code from the locale
     account_locale = locale&.split('_')&.first
     ISO_639.find(account_locale)&.english_name&.downcase || 'english'
+  end
+
+  def knowledge_base_sidebar_enabled
+    value = settings&.fetch('knowledge_base_sidebar_enabled', nil)
+    return true if value.nil?
+
+    ActiveModel::Type::Boolean.new.cast(value)
+  end
+
+  def knowledge_base_sidebar_enabled=(value)
+    self.settings ||= {}
+    settings['knowledge_base_sidebar_enabled'] = ActiveModel::Type::Boolean.new.cast(value)
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -366,3 +366,7 @@ en:
 
       Transcript:
       %{format_messages}
+  activerecord:
+    attributes:
+      account:
+        knowledge_base_sidebar_enabled: Knowledge Base Sidebar (only affects sidebar visibility)


### PR DESCRIPTION
## Summary
- add an account setting "knowledge_base_sidebar_enabled" in account settings
- expose the toggle in Super Admin Account dashboard form/show
- hide/show Knowledge Base item in the dashboard sidebar based on this setting
- default behavior remains enabled when unset

## Scope
- this toggle only affects sidebar visibility
- no API authorization/routing behavior changes
